### PR TITLE
Thingsboard transport

### DIFF
--- a/thingsboard.yaml
+++ b/thingsboard.yaml
@@ -32,7 +32,7 @@ pipeline:
 
   # See https://github.com/Azure/azure-sdk-for-java/issues/25829#issuecomment-988219962
   - runs: | 
-      sed -i 's/<spring-boot.version>3.2.4<\/spring-boot.version>/<spring-boot.version>3.3.2<\/spring-boot.version>/g' pom.xml
+      sed -i "s|<spring-boot.version>3.2.4</spring-boot.version>|<spring-boot.version>3.3.2</spring-boot.version>|g" pom.xml
 
 
   - runs: |

--- a/thingsboard.yaml
+++ b/thingsboard.yaml
@@ -18,7 +18,6 @@ environment:
       - nodejs-16
       - openjdk-17
       - openjdk-17-default-jvm
-      - perl
       - xz
       - yarn
 pipeline:

--- a/thingsboard.yaml
+++ b/thingsboard.yaml
@@ -32,7 +32,7 @@ pipeline:
 
   - runs: | # This manually patches the pom.xml file to use a newer version of json-smart. We need to do this because the latest version of azure is using json-smart 1.3.7
       perl -i -pe 's/<artifactId>asm<\/artifactId>/<artifactId>asm<\/artifactId><\/exclusion><exclusion><groupId>net.minidev<\/groupId><artifactId>json-smart<\/artifactId>/g' pom.xml
-      perl -i -pe 's/<version>\$\{passay.version\}<\/version>/ <version>\$\{passay.version\}<\/version><\/dependency><dependency><groupId>net.minidev<\/groupId><artifactId>json-smart<\/artifactId><version>2.5.1<\/version><\/dependency>/g' pom.xml
+      perl -i -pe 's/<version>\$\{passay.version\}<\/version>/ <version>\$\{passay.version\}<\/version><\/dependency><dependency><groupId>net.minidev<\/groupId><artifactId>json-smart<\/artifactId><version>2.5.1<\/version>/g' pom.xml
 
   - runs: |
       mvn clean install -DskipTests -Dlicense.skip=true

--- a/thingsboard.yaml
+++ b/thingsboard.yaml
@@ -30,11 +30,6 @@ pipeline:
       
   - uses: maven/pombump
 
-  # See https://github.com/Azure/azure-sdk-for-java/issues/25829#issuecomment-988219962
-  - runs: | 
-      sed -i "s|<spring-boot.version>3.2.4</spring-boot.version>|<spring-boot.version>3.3.2</spring-boot.version>|g" pom.xml
-
-
   - runs: |
       mvn clean install -DskipTests -Dlicense.skip=true
 

--- a/thingsboard.yaml
+++ b/thingsboard.yaml
@@ -51,6 +51,10 @@ subpackages:
     dependencies:
       provides:
         - ${{package.name}}-tb-mqtt-transport=${{package.full-version}}
+      runtime:
+        - nodejs-16
+        - openjdk-17
+        - openjdk-17-default-jvm
     pipeline:
       - runs: |
           cd transport/mqtt/target

--- a/thingsboard.yaml
+++ b/thingsboard.yaml
@@ -60,7 +60,7 @@ subpackages:
       pipeline:
         - runs: |
             java -jar /usr/share/tb-mqtt-transport/bin/tb-mqtt-transport.jar > output.log
-            grep -q "Starting ThingsboardMqttTransportApplication v${{package.version}}" output.log && exit 0 || exit 1
+            grep -q "Starting ThingsboardMqttTransportApplication" output.log && exit 0 || exit 1
 
   - name: "${{package.name}}-tb-node"
     description: ""

--- a/thingsboard.yaml
+++ b/thingsboard.yaml
@@ -31,8 +31,8 @@ pipeline:
   - uses: maven/pombump
 
   - runs: | # This manually patches the pom.xml file to use a newer version of json-smart. We need to do this because the latest version of azure is using json-smart 1.3.7
-      perl -pei 's/<artifactId>asm<\/artifactId>/<artifactId>asm<\/artifactId><\/exclusion><exclusion><groupId>net.minidev<\/groupId><artifactId>json-smart<\/artifactId>/g' pom.xml > pom.xml
-      perl -pei 's/<version>\$\{passay.version\}<\/version>/ <version>\$\{passay.version\}<\/version><\/dependency><dependency><groupId>net.minidev<\/groupId><artifactId>json-smart<\/artifactId><version>2.5.1<\/version><\/dependency>/g' pom.xml > pom.xml
+      perl -i -pe 's/<artifactId>asm<\/artifactId>/<artifactId>asm<\/artifactId><\/exclusion><exclusion><groupId>net.minidev<\/groupId><artifactId>json-smart<\/artifactId>/g' pom.xml
+      perl -i -pe 's/<version>\$\{passay.version\}<\/version>/ <version>\$\{passay.version\}<\/version><\/dependency><dependency><groupId>net.minidev<\/groupId><artifactId>json-smart<\/artifactId><version>2.5.1<\/version><\/dependency>/g' pom.xml
 
   - runs: |
       mvn clean install -DskipTests -Dlicense.skip=true

--- a/thingsboard.yaml
+++ b/thingsboard.yaml
@@ -29,12 +29,12 @@ pipeline:
       
   - uses: maven/pombump
 
-  - runs: |
-      mvn clean install -DskipTests -Dlicense.skip=true
-
   - runs: | # This manually patches the pom.xml file to use a newer version of json-smart. We need to do this because the latest version of azure is using json-smart 1.3.7
       perl -pe 's/<artifactId>asm<\/artifactId>/<artifactId>asm<\/artifactId><\/exclusion><exclusion><groupId>net.minidev<\/groupId><artifactId>json-smart<\/artifactId>/g' pom.xml > pom.xml
       perl -pe 's/<version>\$\{passay.version\}<\/version>/ <version>\$\{passay.version\}<\/version><\/dependency><dependency><groupId>net.minidev<\/groupId><artifactId>json-smart<\/artifactId><version>2.5.1<\/version><\/dependency>/g' pom.xml > pom.xml
+
+  - runs: |
+      mvn clean install -DskipTests -Dlicense.skip=true
 
 subpackages:
   - name: "${{package.name}}-tb-js-executor"

--- a/thingsboard.yaml
+++ b/thingsboard.yaml
@@ -5,6 +5,11 @@ package:
   description: "Open-source IoT Platform - Device management, data collection, processing and visualization."
   copyright:
     - license: Apache-2.0
+  dependencies:
+    runtime:
+      - nodejs-16
+      - openjdk-17
+      - openjdk-17-default-jvm
 
 environment:
   contents:
@@ -15,12 +20,8 @@ environment:
       - dpkg # dpkg requires gnutar and xz
       - gnutar
       - maven
-      - nodejs-16
-      - openjdk-17
-      - openjdk-17-default-jvm
       - xz
       - yarn
-
 pipeline:
   - uses: git-checkout
     with:

--- a/thingsboard.yaml
+++ b/thingsboard.yaml
@@ -20,7 +20,7 @@ environment:
       - openjdk-17-default-jvm
       - xz
       - yarn
-      
+
 pipeline:
   - uses: git-checkout
     with:
@@ -60,9 +60,7 @@ subpackages:
     test:
       pipeline:
         - runs: |
-            echo "1"
             java -jar /usr/share/tb-mqtt-transport/bin/tb-mqtt-transport.jar | grep -q "Starting ThingsboardMqttTransportApplication" && exit 0 || exit 1
-            echo "2"
 
   - name: "${{package.name}}-tb-node"
     description: ""

--- a/thingsboard.yaml
+++ b/thingsboard.yaml
@@ -20,6 +20,9 @@ environment:
       - dpkg # dpkg requires gnutar and xz
       - gnutar
       - maven
+      - nodejs-16
+      - openjdk-17
+      - openjdk-17-default-jvm
       - xz
       - yarn
 pipeline:

--- a/thingsboard.yaml
+++ b/thingsboard.yaml
@@ -18,6 +18,7 @@ environment:
       - nodejs-16
       - openjdk-17
       - openjdk-17-default-jvm
+      - perl
       - xz
       - yarn
 pipeline:

--- a/thingsboard.yaml
+++ b/thingsboard.yaml
@@ -32,7 +32,8 @@ pipeline:
 
   # See https://github.com/Azure/azure-sdk-for-java/issues/25829#issuecomment-988219962
   - runs: | 
-      sed -i 's/<spring-boot-starter-web>3.2.4<\/spring-boot-starter-web>/<spring-boot-starter-web>3.3.2<\/spring-boot-starter-web>/g' pom.xml
+      sed -i 's/<spring-boot.version>3.2.4<\/spring-boot.version>/<spring-boot.version>3.3.2<\/spring-boot.version>/g' filename.xml
+
 
   - runs: |
       mvn clean install -DskipTests -Dlicense.skip=true

--- a/thingsboard.yaml
+++ b/thingsboard.yaml
@@ -5,11 +5,6 @@ package:
   description: "Open-source IoT Platform - Device management, data collection, processing and visualization."
   copyright:
     - license: Apache-2.0
-  dependencies:
-    runtime:
-      - nodejs-16
-      - openjdk-17
-      - openjdk-17-default-jvm
 
 environment:
   contents:
@@ -62,8 +57,8 @@ subpackages:
     test:
       pipeline:
         - runs: |
-            echo "TODO: Test tb-mqtt-transport"
-            exit 1
+            java -jar /usr/share/tb-mqtt-transport/bin/tb-mqtt-transport.jar > output.log
+            grep -q "Starting ThingsboardMqttTransportApplication v\${{package.version}}" output.log && exit 0 || exit 1
 
   - name: "${{package.name}}-tb-node"
     description: ""

--- a/thingsboard.yaml
+++ b/thingsboard.yaml
@@ -32,6 +32,10 @@ pipeline:
   - runs: |
       mvn clean install -DskipTests -Dlicense.skip=true
 
+  - runs: | # This manually patches the pom.xml file to use a newer version of json-smart. We need to do this because the latest version of azure is using json-smart 1.3.7
+      perl -pe 's/<artifactId>asm<\/artifactId>/<artifactId>asm<\/artifactId><\/exclusion><exclusion><groupId>net.minidev<\/groupId><artifactId>json-smart<\/artifactId>/g' pom.xml > pom.xml
+      perl -pe 's/<version>\$\{passay.version\}<\/version>/ <version>\$\{passay.version\}<\/version><\/dependency><dependency><groupId>net.minidev<\/groupId><artifactId>json-smart<\/artifactId><version>2.5.1<\/version><\/dependency>/g' pom.xml > pom.xml
+
 subpackages:
   - name: "${{package.name}}-tb-js-executor"
     description: ""

--- a/thingsboard.yaml
+++ b/thingsboard.yaml
@@ -30,9 +30,9 @@ pipeline:
       
   - uses: maven/pombump
 
-  - runs: | # This manually patches the pom.xml file to use a newer version of json-smart. We need to do this because the latest version of azure is using json-smart 1.3.7
-      perl -i -pe 's/<artifactId>asm<\/artifactId>/<artifactId>asm<\/artifactId><\/exclusion><exclusion><groupId>net.minidev<\/groupId><artifactId>json-smart<\/artifactId>/g' pom.xml
-      perl -i -pe 's/<version>\$\{passay.version\}<\/version>/ <version>\$\{passay.version\}<\/version><\/dependency><dependency><groupId>net.minidev<\/groupId><artifactId>json-smart<\/artifactId><version>2.5.1<\/version>/g' pom.xml
+  # See https://github.com/Azure/azure-sdk-for-java/issues/25829#issuecomment-988219962
+  - runs: | 
+      sed -i 's/<spring-boot-starter-web>3.2.4<\/spring-boot-starter-web>/<spring-boot-starter-web>3.3.2<\/spring-boot-starter-web>/g' pom.xml
 
   - runs: |
       mvn clean install -DskipTests -Dlicense.skip=true

--- a/thingsboard.yaml
+++ b/thingsboard.yaml
@@ -26,6 +26,8 @@ pipeline:
       expected-commit: 3528715d2bd5249093ab971bded1fb8b3167210a
       repository: https://github.com/thingsboard/thingsboard.git
       tag: v${{package.version}}
+      
+  - uses: maven/pombump
 
   - runs: |
       mvn clean install -DskipTests -Dlicense.skip=true

--- a/thingsboard.yaml
+++ b/thingsboard.yaml
@@ -57,7 +57,7 @@ subpackages:
     test:
       pipeline:
         - runs: |
-            java -jar /usr/share/tb-mqtt-transport/bin/tb-mqtt-transport.jar > output.log
+            timeout 10s java -jar /usr/share/tb-mqtt-transport/bin/tb-mqtt-transport.jar > output.log
             grep -q "Starting ThingsboardMqttTransportApplication v\${{package.version}}" output.log && exit 0 || exit 1
 
   - name: "${{package.name}}-tb-node"

--- a/thingsboard.yaml
+++ b/thingsboard.yaml
@@ -59,8 +59,9 @@ subpackages:
     test:
       pipeline:
         - runs: |
-            java -jar /usr/share/tb-mqtt-transport/bin/tb-mqtt-transport.jar > output.log
-            grep -q "Starting ThingsboardMqttTransportApplication" output.log && exit 0 || exit 1
+            echo "1"
+            java -jar /usr/share/tb-mqtt-transport/bin/tb-mqtt-transport.jar | grep -q "Starting ThingsboardMqttTransportApplication" && exit 0 || exit 1
+            echo "2"
 
   - name: "${{package.name}}-tb-node"
     description: ""

--- a/thingsboard.yaml
+++ b/thingsboard.yaml
@@ -32,7 +32,7 @@ pipeline:
 
   # See https://github.com/Azure/azure-sdk-for-java/issues/25829#issuecomment-988219962
   - runs: | 
-      sed -i 's/<spring-boot.version>3.2.4<\/spring-boot.version>/<spring-boot.version>3.3.2<\/spring-boot.version>/g' filename.xml
+      sed -i 's/<spring-boot.version>3.2.4<\/spring-boot.version>/<spring-boot.version>3.3.2<\/spring-boot.version>/g' pom.xml
 
 
   - runs: |

--- a/thingsboard.yaml
+++ b/thingsboard.yaml
@@ -49,7 +49,6 @@ subpackages:
         - ${{package.name}}-tb-mqtt-transport=${{package.full-version}}
     pipeline:
       - runs: |
-          mvn clean install -DskipTests -Dlicense.skip=true
           cd transport/mqtt/target
           dpkg-deb -x *.deb ${{targets.subpkgdir}}
     test:

--- a/thingsboard.yaml
+++ b/thingsboard.yaml
@@ -20,6 +20,7 @@ environment:
       - openjdk-17-default-jvm
       - xz
       - yarn
+      
 pipeline:
   - uses: git-checkout
     with:

--- a/thingsboard.yaml
+++ b/thingsboard.yaml
@@ -31,8 +31,8 @@ pipeline:
   - uses: maven/pombump
 
   - runs: | # This manually patches the pom.xml file to use a newer version of json-smart. We need to do this because the latest version of azure is using json-smart 1.3.7
-      perl -pe 's/<artifactId>asm<\/artifactId>/<artifactId>asm<\/artifactId><\/exclusion><exclusion><groupId>net.minidev<\/groupId><artifactId>json-smart<\/artifactId>/g' pom.xml > pom.xml
-      perl -pe 's/<version>\$\{passay.version\}<\/version>/ <version>\$\{passay.version\}<\/version><\/dependency><dependency><groupId>net.minidev<\/groupId><artifactId>json-smart<\/artifactId><version>2.5.1<\/version><\/dependency>/g' pom.xml > pom.xml
+      perl -pei 's/<artifactId>asm<\/artifactId>/<artifactId>asm<\/artifactId><\/exclusion><exclusion><groupId>net.minidev<\/groupId><artifactId>json-smart<\/artifactId>/g' pom.xml > pom.xml
+      perl -pei 's/<version>\$\{passay.version\}<\/version>/ <version>\$\{passay.version\}<\/version><\/dependency><dependency><groupId>net.minidev<\/groupId><artifactId>json-smart<\/artifactId><version>2.5.1<\/version><\/dependency>/g' pom.xml > pom.xml
 
   - runs: |
       mvn clean install -DskipTests -Dlicense.skip=true

--- a/thingsboard.yaml
+++ b/thingsboard.yaml
@@ -58,7 +58,7 @@ subpackages:
       pipeline:
         - runs: |
             java -jar /usr/share/tb-mqtt-transport/bin/tb-mqtt-transport.jar > output.log
-            grep -q "Starting ThingsboardMqttTransportApplication v\${{package.version}}" output.log && exit 0 || exit 1
+            grep -q "Starting ThingsboardMqttTransportApplication v${{package.version}}" output.log && exit 0 || exit 1
 
   - name: "${{package.name}}-tb-node"
     description: ""

--- a/thingsboard.yaml
+++ b/thingsboard.yaml
@@ -57,7 +57,7 @@ subpackages:
     test:
       pipeline:
         - runs: |
-            timeout 10s java -jar /usr/share/tb-mqtt-transport/bin/tb-mqtt-transport.jar > output.log
+            java -jar /usr/share/tb-mqtt-transport/bin/tb-mqtt-transport.jar > output.log
             grep -q "Starting ThingsboardMqttTransportApplication v\${{package.version}}" output.log && exit 0 || exit 1
 
   - name: "${{package.name}}-tb-node"

--- a/thingsboard/pombump-deps.yaml
+++ b/thingsboard/pombump-deps.yaml
@@ -1,7 +1,0 @@
-patches:
-  # Fixes CVE-2024-34750
-  - groupId: org.springframework.boot
-    artifactId: spring-boot-starter-web
-    version: 3.3.2
-    scope: compile
-    type: pom

--- a/thingsboard/pombump-deps.yaml
+++ b/thingsboard/pombump-deps.yaml
@@ -1,0 +1,7 @@
+patches:
+  # Fixes CVE-2022-24329 and CVE-2020-29582
+  - groupId: com.squareup.wire
+    artifactId: wire-schema
+    version: 5.0.0
+    scope: compile
+    type: pom

--- a/thingsboard/pombump-deps.yaml
+++ b/thingsboard/pombump-deps.yaml
@@ -5,3 +5,8 @@ patches:
     version: 3.3.2
     scope: compile
     type: pom
+  - groupId: net.minidev
+    artifactId: json-smart
+    version: 2.5.1
+    scope: compile
+    type: pom

--- a/thingsboard/pombump-deps.yaml
+++ b/thingsboard/pombump-deps.yaml
@@ -2,6 +2,6 @@ patches:
   # Fixes CVE-2022-24329 and CVE-2020-29582
   - groupId: com.squareup.wire
     artifactId: wire-schema
-    version: 5.0.0
+    version: 3.7.1
     scope: compile
     type: pom

--- a/thingsboard/pombump-deps.yaml
+++ b/thingsboard/pombump-deps.yaml
@@ -5,8 +5,3 @@ patches:
     version: 3.3.2
     scope: compile
     type: pom
-  - groupId: net.minidev
-    artifactId: json-smart
-    version: 2.5.1
-    scope: compile
-    type: pom

--- a/thingsboard/pombump-deps.yaml
+++ b/thingsboard/pombump-deps.yaml
@@ -1,14 +1,9 @@
 patches:
   # Fixes CVE-2024-34750
-  # We are bumping this singular artfact and not the entirety of spring boot, because thingsboard uses sslStoreProvider.
+  # Bumping this singular artfact and not the entirety of spring boot, because thingsboard uses SslStoreProvider.
   # See https://javadoc.io/doc/org.springframework.boot/spring-boot/3.2.4/org/springframework/boot/web/server/SslStoreProvider.html
   - groupId: org.springframework.boot
     artifactId: spring-boot-starter-web
     version: 3.3.2
     scope: compile
     type: pom
-
-# okio is a transitive dependency of wire schema which will be bumped across a major version
-# nimbus-jose-jwt is a transitive dependency of azure-client-authentication which was last updated 3 years ago
-# json-smart 2.4.2 is a transitive dependency of azure-client-authentication which was last updated 3 years ago
-# json-smart 1.3.2 is compiled into one of the jars in thingsboard-mqtt-transport

--- a/thingsboard/pombump-deps.yaml
+++ b/thingsboard/pombump-deps.yaml
@@ -1,7 +1,7 @@
 patches:
-  # Fixes CVE-2022-24329 and CVE-2020-29582
-  - groupId: com.squareup.wire
-    artifactId: wire-schema
-    version: 3.7.1
+  # Fixes CVE-2024-34750
+  - groupId: org.springframework.boot
+    artifactId: spring-boot-starter-web
+    version: 3.3.2
     scope: compile
     type: pom

--- a/thingsboard/pombump-deps.yaml
+++ b/thingsboard/pombump-deps.yaml
@@ -7,3 +7,8 @@ patches:
     version: 3.3.2
     scope: compile
     type: pom
+
+# okio is a transitive dependency of wire schema which will be bumped across a major version
+# nimbus-jose-jwt is a transitive dependency of azure-client-authentication which was last updated 3 years ago
+# json-smart 2.4.2 is a transitive dependency of azure-client-authentication which was last updated 3 years ago
+# json-smart 1.3.2 is compiled into one of the jars in thingsboard-mqtt-transport

--- a/thingsboard/pombump-deps.yaml
+++ b/thingsboard/pombump-deps.yaml
@@ -1,0 +1,9 @@
+patches:
+  # Fixes CVE-2024-34750
+  # We are bumping this singular artfact and not the entirety of spring boot, because thingsboard uses sslStoreProvider.
+  # See https://javadoc.io/doc/org.springframework.boot/spring-boot/3.2.4/org/springframework/boot/web/server/SslStoreProvider.html
+  - groupId: org.springframework.boot
+    artifactId: spring-boot-starter-web
+    version: 3.3.2
+    scope: compile
+    type: pom


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
